### PR TITLE
Initialize Next.js 14 scaffold with Tailwind

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+out
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.env
+
+# optional
+.idea
+.vscode

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "slp-pink-studio",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.4.2",
+    "@types/react": "18.2.15",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.3.2",
+    "typescript": "5.0.4"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply antialiased;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,38 @@
+import './globals.css'
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+
+export const metadata = {
+  title: 'SLP Pink Studio',
+  description: 'School-based speech-language pathologist dashboard'
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="flex min-h-screen bg-gray-50">
+        <nav className="w-64 bg-primary text-white p-4 rounded-r-md">
+          <h1 className="mb-8 text-2xl font-semibold">SLP Pink Studio</h1>
+          <ul className="space-y-2">
+            <li>
+              <Link href="/" className="block rounded-md px-4 py-2 hover:bg-white/20">Dashboard</Link>
+            </li>
+            <li>
+              <Link href="/students" className="block rounded-md px-4 py-2 hover:bg-white/20">Students</Link>
+            </li>
+            <li>
+              <Link href="/schedule" className="block rounded-md px-4 py-2 hover:bg-white/20">Schedule</Link>
+            </li>
+            <li>
+              <Link href="/reports" className="block rounded-md px-4 py-2 hover:bg-white/20">Reports</Link>
+            </li>
+            <li>
+              <Link href="/settings" className="block rounded-md px-4 py-2 hover:bg-white/20">Settings</Link>
+            </li>
+          </ul>
+        </nav>
+        <main className="flex-1 p-8">{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,8 @@
+export default function DashboardPage() {
+  return (
+    <section className="rounded-md bg-white p-6 shadow">
+      <h2 className="text-xl font-semibold">Dashboard</h2>
+      <p className="mt-4 text-gray-600">Welcome to SLP Pink Studio.</p>
+    </section>
+  )
+}

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,0 +1,8 @@
+export default function ReportsPage() {
+  return (
+    <section className="rounded-md bg-white p-6 shadow">
+      <h2 className="text-xl font-semibold">Reports</h2>
+      <p className="mt-4 text-gray-600">Generate and review reports here.</p>
+    </section>
+  )
+}

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,0 +1,8 @@
+export default function SchedulePage() {
+  return (
+    <section className="rounded-md bg-white p-6 shadow">
+      <h2 className="text-xl font-semibold">Schedule</h2>
+      <p className="mt-4 text-gray-600">View and plan your schedule.</p>
+    </section>
+  )
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,8 @@
+export default function SettingsPage() {
+  return (
+    <section className="rounded-md bg-white p-6 shadow">
+      <h2 className="text-xl font-semibold">Settings</h2>
+      <p className="mt-4 text-gray-600">Adjust your preferences.</p>
+    </section>
+  )
+}

--- a/src/app/students/page.tsx
+++ b/src/app/students/page.tsx
@@ -1,0 +1,8 @@
+export default function StudentsPage() {
+  return (
+    <section className="rounded-md bg-white p-6 shadow">
+      <h2 className="text-xl font-semibold">Students</h2>
+      <p className="mt-4 text-gray-600">Manage student information here.</p>
+    </section>
+  )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: "#f5bcd6"
+      },
+      borderRadius: {
+        DEFAULT: "0.5rem"
+      }
+    }
+  },
+  plugins: []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 app router project with TypeScript
- configure Tailwind CSS with custom primary color and rounded corners
- add global layout with left navigation and placeholder pages for dashboard, students, schedule, reports, and settings

## Testing
- `npm run lint` (fails: next not found)
- `npm run build` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_e_6896cbb1c6988330bc7dd229cbeec9a9