### PR TITLE
feat: add interactive schedule grid and session modal

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,7 @@ model Student {
   classroomId Int
   goals       StudentGoal[]
   notes       Note[]
+  groups      Group[]   @relation("GroupStudents")
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
 }
@@ -79,6 +80,7 @@ model Group {
   id        Int       @id @default(autoincrement())
   name      String
   sessions  Session[]
+  students  Student[] @relation("GroupStudents")
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
 }
@@ -92,6 +94,7 @@ model Session {
   group     Group?   @relation(fields: [groupId], references: [id])
   groupId   Int?
   notes     Note[]
+  status    String @default("UPCOMING")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }

--- a/src/app/schedule/actions.ts
+++ b/src/app/schedule/actions.ts
@@ -1,0 +1,67 @@
+'use server'
+
+import prisma from '@/lib/prisma'
+import { SessionStatus, SessionWithGroup } from '@/types/schedule'
+
+export async function getSessionsForRange(
+  start: Date,
+  end: Date,
+): Promise<SessionWithGroup[]> {
+  return prisma.session.findMany({
+    where: { date: { gte: start, lt: end } },
+    include: { group: { include: { students: true } } },
+    orderBy: { startTime: 'asc' },
+  }) as any
+}
+
+interface SaveSessionInput {
+  id?: number
+  date: string
+  startTime: string
+  endTime: string
+  location: string
+  studentIds: number[]
+  groupName?: string
+  status: SessionStatus
+}
+
+export async function saveSession(input: SaveSessionInput): Promise<SessionWithGroup> {
+  const { id, date, startTime, endTime, location, studentIds, groupName, status } = input
+
+  const start = new Date(`${date}T${startTime}:00`)
+  const end = new Date(`${date}T${endTime}:00`)
+  const sessionDate = new Date(date)
+
+  let groupId: number | undefined
+  if (studentIds.length > 0) {
+    const group = await prisma.group.create({
+      data: {
+        name: groupName || 'Session Group',
+        students: { connect: studentIds.map((id) => ({ id })) },
+      },
+    })
+    groupId = group.id
+  }
+
+  const session = id
+    ? await prisma.session.update({
+        where: { id },
+        data: { date: sessionDate, startTime: start, endTime: end, location, groupId, status },
+      })
+    : await prisma.session.create({
+        data: { date: sessionDate, startTime: start, endTime: end, location, groupId, status },
+      })
+
+  return (await prisma.session.findUnique({
+    where: { id: session.id },
+    include: { group: { include: { students: true } } },
+  })) as any
+}
+
+export async function markSessionSeen(id: number): Promise<SessionWithGroup> {
+  return prisma.session.update({
+    where: { id },
+    data: { status: 'SEEN' },
+    include: { group: { include: { students: true } } },
+  }) as any
+}

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,8 +1,29 @@
-export default function SchedulePage() {
+import ScheduleGrid from '@/components/schedule/ScheduleGrid'
+import prisma from '@/lib/prisma'
+
+function startOfCurrentWeek() {
+  const now = new Date()
+  const day = now.getDay()
+  const diff = now.getDate() - day + (day === 0 ? -6 : 1)
+  return new Date(now.getFullYear(), now.getMonth(), diff)
+}
+
+export default async function SchedulePage() {
+  const weekStart = startOfCurrentWeek()
+  const sessions = await prisma.session.findMany({
+    where: { date: { gte: weekStart, lt: new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000) } },
+    include: { group: { include: { students: true } } },
+    orderBy: { startTime: 'asc' },
+  })
+  const students = await prisma.student.findMany({ orderBy: { firstName: 'asc' } })
   return (
-    <section className="rounded-md bg-white p-6 shadow">
-      <h2 className="text-xl font-semibold">Schedule</h2>
-      <p className="mt-4 text-gray-600">View and plan your schedule.</p>
+    <section className="rounded-md bg-white p-2 shadow">
+      <h2 className="mb-4 text-xl font-semibold">Schedule</h2>
+      <ScheduleGrid
+        initialWeekStart={weekStart}
+        initialSessions={sessions as any}
+        students={students}
+      />
     </section>
   )
 }

--- a/src/components/schedule/ScheduleBlock.tsx
+++ b/src/components/schedule/ScheduleBlock.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useState } from 'react'
+import SessionModal from './SessionModal'
+import { Student } from '@prisma/client'
+import { SessionWithGroup } from '@/types/schedule'
+
+interface Props {
+  date: Date
+  time: string
+  session?: SessionWithGroup
+  students: Student[]
+  onChange: (session: SessionWithGroup) => void
+}
+
+export default function ScheduleBlock({ date, time, session, students, onChange }: Props) {
+  const [open, setOpen] = useState(false)
+
+  const status = session?.status ?? 'UPCOMING'
+  const color =
+    status === 'SEEN'
+      ? 'bg-pink-400'
+      : status === 'MISSED'
+      ? 'bg-gray-300'
+      : session
+      ? 'bg-[#f5bcd6]'
+      : ''
+
+  return (
+    <>
+      <div
+        className={`h-16 w-full border p-1 text-xs cursor-pointer ${color}`}
+        onClick={() => setOpen(true)}
+      >
+        {session && (
+          <div className="truncate">
+            {session.group?.name ||
+              session.group?.students.map((s) => s.firstName).join(', ')}
+          </div>
+        )}
+      </div>
+      {open && (
+        <SessionModal
+          initialDate={date}
+          initialTime={time}
+          session={session}
+          students={students}
+          onClose={() => setOpen(false)}
+          onSave={(s) => {
+            onChange(s)
+            setOpen(false)
+          }}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/schedule/ScheduleGrid.tsx
+++ b/src/components/schedule/ScheduleGrid.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useState, useTransition, Fragment } from 'react'
+import { addDays } from '@/utils/date'
+import { getSessionsForRange } from '@/app/schedule/actions'
+import ScheduleBlock from './ScheduleBlock'
+import { Student } from '@prisma/client'
+import { SessionWithGroup } from '@/types/schedule'
+
+interface Props {
+  initialWeekStart: Date
+  initialSessions: SessionWithGroup[]
+  students: Student[]
+}
+
+const times = Array.from({ length: 8 }, (_, i) => `${8 + i}:00`)
+const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']
+
+export default function ScheduleGrid({
+  initialWeekStart,
+  initialSessions,
+  students,
+}: Props) {
+  const [weekStart, setWeekStart] = useState(new Date(initialWeekStart))
+  const [sessions, setSessions] = useState<SessionWithGroup[]>(initialSessions)
+  const [pending, startTransition] = useTransition()
+
+  function startOfDay(date: Date) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  }
+
+  async function changeWeek(offset: number) {
+    const newStart = addDays(weekStart, offset * 7)
+    startTransition(async () => {
+      const newSessions = await getSessionsForRange(newStart, addDays(newStart, 7))
+      setWeekStart(newStart)
+      setSessions(newSessions)
+    })
+  }
+
+  function findSession(day: number, time: string) {
+    const date = addDays(weekStart, day)
+    return sessions.find((s) => {
+      const sameDay = startOfDay(new Date(s.date)).getTime() === startOfDay(date).getTime()
+      const st = new Date(s.startTime)
+      const hh = st.getHours().toString().padStart(2, '0')
+      return sameDay && `${hh}:00` === time
+    })
+  }
+
+  function upsertSession(session: SessionWithGroup) {
+    setSessions((prev) => {
+      const existing = prev.findIndex((p) => p.id === session.id)
+      if (existing >= 0) {
+        const clone = [...prev]
+        clone[existing] = session
+        return clone
+      }
+      return [...prev, session]
+    })
+  }
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <button
+          onClick={() => changeWeek(-1)}
+          className="rounded bg-pink-200 px-2 py-1 text-pink-900"
+        >
+          Prev
+        </button>
+        <div className="font-semibold text-pink-800">
+          Week of {weekStart.toLocaleDateString()}
+        </div>
+        <button
+          onClick={() => changeWeek(1)}
+          className="rounded bg-pink-200 px-2 py-1 text-pink-900"
+        >
+          Next
+        </button>
+      </div>
+      <div className="grid grid-cols-6 gap-px">
+        <div></div>
+        {days.map((d) => (
+          <div key={d} className="p-2 text-center font-semibold">
+            {d}
+          </div>
+        ))}
+        {times.map((t) => (
+          <Fragment key={t}>
+            <div className="p-2 text-right text-sm">{t}</div>
+            {days.map((_, i) => {
+              const date = addDays(weekStart, i)
+              const session = findSession(i, t)
+              return (
+                <ScheduleBlock
+                  key={`${i}-${t}`}
+                  date={date}
+                  time={t}
+                  session={session}
+                  students={students}
+                  onChange={upsertSession}
+                />
+              )
+            })}
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/schedule/SessionModal.tsx
+++ b/src/components/schedule/SessionModal.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useState } from 'react'
+import { Student } from '@prisma/client'
+import { saveSession } from '@/app/schedule/actions'
+import { SessionWithGroup, SessionStatus, SESSION_STATUSES } from '@/types/schedule'
+
+interface Props {
+  initialDate: Date
+  initialTime: string
+  session?: SessionWithGroup
+  students: Student[]
+  onClose: () => void
+  onSave: (session: SessionWithGroup) => void
+}
+
+const times = Array.from({ length: 9 }, (_, i) => `${8 + i}:00`)
+const locations = ['Room 1', 'Room 2', 'Room 3']
+
+export default function SessionModal({
+  initialDate,
+  initialTime,
+  session,
+  students,
+  onClose,
+  onSave,
+}: Props) {
+  const [date, setDate] = useState(
+    session ? session.date.toISOString().substring(0, 10) : initialDate.toISOString().substring(0, 10)
+  )
+  const [startTime, setStartTime] = useState(
+    session
+      ? new Date(session.startTime).toLocaleTimeString([], {
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false,
+        })
+      : initialTime
+  )
+  const [endTime, setEndTime] = useState(
+    session
+      ? new Date(session.endTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false })
+      : times[times.indexOf(initialTime) + 1] || initialTime
+  )
+  const [location, setLocation] = useState(session?.location || '')
+  const [selected, setSelected] = useState<number[]>(
+    session?.group?.students.map((s) => s.id) || []
+  )
+  const [groupName, setGroupName] = useState(session?.group?.name || '')
+  const [status, setStatus] = useState<SessionStatus>(session?.status || 'UPCOMING')
+  const [saving, setSaving] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    const saved = await saveSession({
+      id: session?.id,
+      date,
+      startTime,
+      endTime,
+      location,
+      studentIds: selected,
+      groupName,
+      status,
+    })
+    onSave(saved)
+  }
+
+  function toggle(id: number) {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]
+    )
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30">
+      <form
+        onSubmit={handleSubmit}
+        className="w-80 rounded-lg bg-pink-50 p-4 shadow-lg"
+      >
+        <h2 className="mb-2 text-lg font-semibold text-pink-800">
+          {session ? 'Edit Session' : 'New Session'}
+        </h2>
+        <div className="mb-2">
+          <label className="block text-sm text-pink-800">Date</label>
+          <input
+            type="date"
+            className="mt-1 w-full rounded border-pink-300 bg-pink-100 p-1"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+        </div>
+        <div className="mb-2 flex gap-2">
+          <div className="flex-1">
+            <label className="block text-sm text-pink-800">Start</label>
+            <select
+              className="mt-1 w-full rounded border-pink-300 bg-pink-100 p-1"
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+            >
+              {times.map((t) => (
+                <option key={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex-1">
+            <label className="block text-sm text-pink-800">End</label>
+            <select
+              className="mt-1 w-full rounded border-pink-300 bg-pink-100 p-1"
+              value={endTime}
+              onChange={(e) => setEndTime(e.target.value)}
+            >
+              {times.map((t) => (
+                <option key={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className="mb-2">
+          <label className="block text-sm text-pink-800">Location</label>
+          <select
+            className="mt-1 w-full rounded border-pink-300 bg-pink-100 p-1"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+          >
+            <option value="">Select</option>
+            {locations.map((l) => (
+              <option key={l}>{l}</option>
+            ))}
+          </select>
+        </div>
+        <div className="mb-2">
+          <label className="block text-sm text-pink-800">Students</label>
+          <div className="mt-1 max-h-24 overflow-y-auto rounded border border-pink-300 bg-pink-100 p-1">
+            {students.map((s) => (
+              <label key={s.id} className="flex items-center gap-1 text-sm">
+                <input
+                  type="checkbox"
+                  checked={selected.includes(s.id)}
+                  onChange={() => toggle(s.id)}
+                />
+                {s.firstName} {s.lastName}
+              </label>
+            ))}
+          </div>
+        </div>
+        <div className="mb-2">
+          <label className="block text-sm text-pink-800">Group Name (optional)</label>
+          <input
+            type="text"
+            className="mt-1 w-full rounded border-pink-300 bg-pink-100 p-1"
+            value={groupName}
+            onChange={(e) => setGroupName(e.target.value)}
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-sm text-pink-800">Status</label>
+          <select
+            className="mt-1 w-full rounded border-pink-300 bg-pink-100 p-1"
+            value={status}
+            onChange={(e) => setStatus(e.target.value as SessionStatus)}
+          >
+            {SESSION_STATUSES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            className="rounded bg-pink-200 px-3 py-1 text-pink-900"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded bg-pink-500 px-3 py-1 text-white disabled:opacity-50"
+          >
+            Save
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined }
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({ log: ['query', 'info', 'warn', 'error'] })
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+
+export default prisma

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,0 +1,10 @@
+import { Session, Group, Student } from '@prisma/client'
+
+export type SessionStatus = 'UPCOMING' | 'SEEN' | 'MISSED'
+
+export type SessionWithGroup = Session & {
+  group: (Group & { students: Student[] }) | null
+  status: SessionStatus
+}
+
+export const SESSION_STATUSES: SessionStatus[] = ['UPCOMING', 'SEEN', 'MISSED']

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,5 @@
+export function addDays(date: Date, days: number) {
+  const d = new Date(date)
+  d.setDate(d.getDate() + days)
+  return d
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -14,8 +18,28 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "src/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- build weekly schedule page with navigation and grid components
- add modal to create or edit sessions linked with students or groups
- extend Prisma schema for session status and group membership

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Environment variable not found: DATABASE_URL)

------
https://chatgpt.com/codex/tasks/task_e_6896d4d375788330835db5b71ac04798