### PR TITLE
Add auto note generator workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "next": "14.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "@prisma/client": "^5.11.0"
+    "@prisma/client": "^5.11.0",
+    "@headlessui/react": "^1.7.15"
   },
   "devDependencies": {
     "@types/node": "20.4.2",

--- a/prisma/noteExamples.ts
+++ b/prisma/noteExamples.ts
@@ -1,0 +1,30 @@
+import { prisma } from '../src/lib/prisma'
+
+export async function createNoteExample() {
+  return prisma.note.create({
+    data: {
+      text: 'Example note',
+      session: { connect: { id: 1 } },
+      student: { connect: { id: 1 } },
+      goalData: {
+        create: [
+          {
+            accuracy: 80,
+            trials: 10,
+            studentGoal: { connect: { id: 1 } }
+          }
+        ]
+      }
+    }
+  })
+}
+
+export async function getNotesForStudent(studentId: number) {
+  return prisma.note.findMany({
+    where: { studentId },
+    include: {
+      session: true,
+      goalData: { include: { studentGoal: { include: { goal: true } } } }
+    }
+  })
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,7 @@ model StudentGoal {
   goalId    Int
   status    String
   notes     String?
+  goalData  NoteGoalData[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -103,7 +104,24 @@ model Note {
   student   Student  @relation(fields: [studentId], references: [id])
   studentId Int
   text      String
+  location  String?
+  activity  String?
+  prompting String?
+  comments  String?
+  goalData  NoteGoalData[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model NoteGoalData {
+  id            Int         @id @default(autoincrement())
+  note          Note        @relation(fields: [noteId], references: [id])
+  noteId        Int
+  studentGoal   StudentGoal @relation(fields: [studentGoalId], references: [id])
+  studentGoalId Int
+  accuracy      Int
+  trials        Int
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
 }
 

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '../../../lib/prisma'
+
+export async function POST(req: Request) {
+  const data = await req.json()
+
+  const note = await prisma.note.create({
+    data: {
+      text: data.text,
+      location: data.location,
+      activity: data.activity,
+      prompting: data.prompting,
+      comments: data.comments,
+      session: { connect: { id: data.sessionId } },
+      student: { connect: { id: data.studentId } },
+      goalData: {
+        create: (data.goalData || []).map((g: any) => ({
+          accuracy: g.accuracy,
+          trials: g.trials,
+          studentGoal: { connect: { id: g.studentGoalId } }
+        }))
+      }
+    }
+  })
+
+  return NextResponse.json(note)
+}

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,8 +1,52 @@
+'use client'
+
+import { useState } from 'react'
+import NoteFormModal from '../../components/NoteFormModal'
+import ScheduleSessionModal from '../../components/ScheduleSessionModal'
+
+const dummyStudent = {
+  id: 1,
+  firstName: 'Martina',
+  goals: [
+    { id: 1, goal: { description: "used the phrase 'I see' to comment" } },
+    { id: 2, goal: { description: 'labeled items' } }
+  ]
+}
+
+const dummySession = { id: 1, title: 'Speech Session with Martina', location: 'Therapy Room' }
+
 export default function SchedulePage() {
+  const [sessionOpen, setSessionOpen] = useState(false)
+  const [noteOpen, setNoteOpen] = useState(false)
+
+  const handleMarkSeen = () => {
+    setSessionOpen(false)
+    setNoteOpen(true)
+  }
+
   return (
     <section className="rounded-md bg-white p-6 shadow">
       <h2 className="text-xl font-semibold">Schedule</h2>
       <p className="mt-4 text-gray-600">View and plan your schedule.</p>
+      <div className="mt-6">
+        <button className="rounded-md bg-primary px-4 py-2 text-white" onClick={() => setSessionOpen(true)}>
+          Open Session
+        </button>
+      </div>
+      <ScheduleSessionModal
+        isOpen={sessionOpen}
+        onClose={() => setSessionOpen(false)}
+        onMarkSeen={handleMarkSeen}
+        session={dummySession}
+      />
+      <NoteFormModal
+        isOpen={noteOpen}
+        onClose={() => setNoteOpen(false)}
+        sessionId={dummySession.id}
+        studentId={dummyStudent.id}
+        studentName={dummyStudent.firstName}
+        goals={dummyStudent.goals}
+      />
     </section>
   )
 }

--- a/src/components/NoteFormModal.tsx
+++ b/src/components/NoteFormModal.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { Dialog, Transition } from '@headlessui/react'
+import { Fragment, useState } from 'react'
+import { generateNoteParagraph, GoalPerformance } from '../lib/generateNoteParagraph'
+
+interface StudentGoal {
+  id: number
+  goal: { description: string }
+}
+
+interface NoteFormModalProps {
+  isOpen: boolean
+  onClose: () => void
+  sessionId: number
+  studentId: number
+  studentName: string
+  goals: StudentGoal[]
+}
+
+export default function NoteFormModal({ isOpen, onClose, sessionId, studentId, studentName, goals }: NoteFormModalProps) {
+  const [location, setLocation] = useState('')
+  const [activity, setActivity] = useState('')
+  const [prompting, setPrompting] = useState('none')
+  const [goalData, setGoalData] = useState<Record<number, { accuracy: number; trials: number }>>({})
+  const [comments, setComments] = useState('')
+  const [noteText, setNoteText] = useState('')
+
+  const handleGenerate = () => {
+    const goalPerf: GoalPerformance[] = goals.map(g => ({
+      goalDescription: g.goal.description,
+      accuracy: goalData[g.id]?.accuracy ?? 0,
+      trials: goalData[g.id]?.trials ?? 0
+    }))
+    const text = generateNoteParagraph({
+      studentName,
+      activity,
+      prompting,
+      goals: goalPerf,
+      comments
+    })
+    setNoteText(text)
+  }
+
+  const handleSave = async () => {
+    await fetch('/api/notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionId,
+        studentId,
+        text: noteText,
+        location,
+        activity,
+        prompting,
+        comments,
+        goalData: Object.entries(goalData).map(([studentGoalId, data]) => ({
+          studentGoalId: Number(studentGoalId),
+          accuracy: data.accuracy,
+          trials: data.trials
+        }))
+      })
+    })
+    onClose()
+  }
+
+  return (
+    <Transition show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/25" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-lg transform rounded-md bg-white p-6 text-left align-middle shadow-xl transition-all">
+                <Dialog.Title className="text-lg font-medium text-gray-900 mb-4">Session Note</Dialog.Title>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">Location</label>
+                    <select value={location} onChange={e => setLocation(e.target.value)} className="mt-1 w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary">
+                      <option value="">Select...</option>
+                      <option value="classroom">Classroom</option>
+                      <option value="therapy room">Therapy Room</option>
+                      <option value="outside">Outside</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">Activity Description</label>
+                    <input value={activity} onChange={e => setActivity(e.target.value)} className="mt-1 w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary" />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">Prompting Type</label>
+                    <select value={prompting} onChange={e => setPrompting(e.target.value)} className="mt-1 w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary">
+                      <option value="verbal">Verbal</option>
+                      <option value="visual">Visual</option>
+                      <option value="physical">Physical</option>
+                      <option value="gestural">Gestural</option>
+                      <option value="none">None</option>
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    {goals.map(g => (
+                      <div key={g.id} className="rounded-md bg-primary/20 p-2">
+                        <p className="text-sm font-medium">{g.goal.description}</p>
+                        <div className="mt-1 flex space-x-2">
+                          <input
+                            type="number"
+                            placeholder="Accuracy %"
+                            className="w-1/2 rounded-md border-gray-300 focus:border-primary focus:ring-primary"
+                            value={goalData[g.id]?.accuracy ?? ''}
+                            onChange={e => setGoalData(prev => ({ ...prev, [g.id]: { ...prev[g.id], accuracy: Number(e.target.value) } }))}
+                          />
+                          <input
+                            type="number"
+                            placeholder="Trials"
+                            className="w-1/2 rounded-md border-gray-300 focus:border-primary focus:ring-primary"
+                            value={goalData[g.id]?.trials ?? ''}
+                            onChange={e => setGoalData(prev => ({ ...prev, [g.id]: { ...prev[g.id], trials: Number(e.target.value) } }))}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">Comments</label>
+                    <textarea value={comments} onChange={e => setComments(e.target.value)} className="mt-1 w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary" />
+                  </div>
+                  <div>
+                    <button type="button" onClick={handleGenerate} className="rounded-md bg-primary px-4 py-2 text-white">Generate</button>
+                  </div>
+                  {noteText && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700">Generated Note</label>
+                      <textarea value={noteText} onChange={e => setNoteText(e.target.value)} className="mt-1 w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary" rows={4} />
+                    </div>
+                  )}
+                </div>
+                <div className="mt-6 flex justify-end space-x-2">
+                  <button type="button" className="rounded-md bg-gray-200 px-4 py-2" onClick={onClose}>Cancel</button>
+                  <button type="button" className="rounded-md bg-primary px-4 py-2 text-white" onClick={handleSave}>Save</button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}

--- a/src/components/ScheduleSessionModal.tsx
+++ b/src/components/ScheduleSessionModal.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { Dialog, Transition } from '@headlessui/react'
+import { Fragment } from 'react'
+
+interface SessionModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onMarkSeen: () => void
+  session: { id: number; title: string; location?: string }
+}
+
+export default function ScheduleSessionModal({ isOpen, onClose, onMarkSeen, session }: SessionModalProps) {
+  return (
+    <Transition show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/25" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform rounded-md bg-white p-6 text-left align-middle shadow-xl transition-all">
+                <Dialog.Title className="text-lg font-medium text-gray-900 mb-4">{session.title}</Dialog.Title>
+                <p className="mb-4 text-sm text-gray-700">Location: {session.location ?? 'TBD'}</p>
+                <div className="mt-6 flex justify-end space-x-2">
+                  <button type="button" className="rounded-md bg-gray-200 px-4 py-2" onClick={onClose}>Close</button>
+                  <button type="button" className="rounded-md bg-primary px-4 py-2 text-white" onClick={onMarkSeen}>Mark Seen</button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}

--- a/src/lib/generateNoteParagraph.ts
+++ b/src/lib/generateNoteParagraph.ts
@@ -1,0 +1,36 @@
+export interface GoalPerformance {
+  goalDescription: string
+  accuracy: number
+  trials: number
+}
+
+export interface NoteData {
+  studentName: string
+  activity: string
+  prompting: string
+  goals: GoalPerformance[]
+  comments?: string
+}
+
+export function generateNoteParagraph(data: NoteData): string {
+  const parts: string[] = []
+  parts.push(`${data.studentName} was engaged and participated throughout the session.`)
+
+  if (data.activity) {
+    parts.push(`Activities included ${data.activity}.`)
+  }
+
+  data.goals.forEach(g => {
+    parts.push(`${data.studentName} ${g.goalDescription} ${g.trials}x with ${g.accuracy}% accuracy.`)
+  })
+
+  if (data.prompting && data.prompting !== 'none') {
+    parts.push(`${data.studentName} required ${data.prompting} prompting.`)
+  }
+
+  if (data.comments) {
+    parts.push(data.comments)
+  }
+
+  return parts.join(' ')
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined
+}
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma


### PR DESCRIPTION
## Summary
- add HeadlessUI-based note form that opens after marking a session as seen
- create generateNoteParagraph utility to craft narrative notes from session data
- store note text and goal accuracy data with Prisma schema updates and API route

## Testing
- `npx prisma generate`
- `npx prisma validate` *(fails: Environment variable not found: DATABASE_URL)*
- `npm run lint` *(fails: ESLint must be installed; npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6896d52ba6b483309d37b1d105636fda