### PR TITLE
refactor: unify Prisma client export

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,10 +1,17 @@
 import { PrismaClient } from '@prisma/client'
 
-const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined }
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined
+}
+
+const datasourceUrl = process.env.DATABASE_URL
 
 export const prisma =
   globalForPrisma.prisma ??
-  new PrismaClient({ log: ['query', 'info', 'warn', 'error'] })
+  new PrismaClient({
+    log: ['query', 'info', 'warn', 'error'],
+    datasources: { db: { url: datasourceUrl } }
+  })
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 


### PR DESCRIPTION
## Summary
- ensure prisma client uses env-based datasource and single export

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint must be installed: yarn add --dev eslint)*
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_6896d912b4e08330aee12b658ad52c4e