### PR TITLE
feat: add note form modal to schedule

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,4 +1,5 @@
 import ScheduleGrid from '@/components/schedule/ScheduleGrid'
+import NoteFormModal from '@/components/notes/NoteFormModal'
 import prisma from '@/lib/prisma'
 
 function startOfCurrentWeek() {
@@ -16,6 +17,8 @@ export default async function SchedulePage() {
     orderBy: { startTime: 'asc' },
   })
   const students = await prisma.student.findMany({ orderBy: { firstName: 'asc' } })
+  const sessionForNote = sessions[0]
+  const studentForNote = sessionForNote?.group?.students[0] || students[0]
   return (
     <section className="rounded-md bg-white p-2 shadow">
       <h2 className="mb-4 text-xl font-semibold">Schedule</h2>
@@ -24,6 +27,11 @@ export default async function SchedulePage() {
         initialSessions={sessions as any}
         students={students}
       />
+      {sessionForNote && studentForNote && (
+        <div className="mt-4">
+          <NoteFormModal student={studentForNote} session={sessionForNote as any} />
+        </div>
+      )}
     </section>
   )
 }

--- a/src/components/notes/NoteFormModal.tsx
+++ b/src/components/notes/NoteFormModal.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState } from 'react'
+import { Student } from '@prisma/client'
+import { SessionWithGroup } from '@/types/schedule'
+
+interface NoteFormModalProps {
+  student: Student
+  session: SessionWithGroup
+}
+
+export default function NoteFormModal({ student, session }: NoteFormModalProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded bg-pink-200 px-2 py-1 text-pink-900"
+      >
+        Add Note
+      </button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30">
+          <div className="rounded-lg bg-white p-4 shadow-lg text-sm">
+            <h2 className="mb-2 text-lg font-semibold text-pink-800">
+              Add Note for {student.firstName} {student.lastName}
+            </h2>
+            <p className="mb-2">
+              Session: {session.group?.name || 'Session'}
+            </p>
+            <textarea
+              className="w-full rounded border border-pink-300 bg-pink-100 p-1"
+              rows={4}
+            ></textarea>
+            <div className="mt-2 flex justify-end">
+              <button
+                onClick={() => setOpen(false)}
+                className="rounded bg-pink-200 px-3 py-1 text-pink-900"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add basic NoteFormModal component
- integrate NoteFormModal in schedule page using real session and student data

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run build` *(fails: ESLint must be installed; Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6896d911a4888330bef8a95596818451