### PR TITLE
fix: use type-only Prisma imports in schedule

### DIFF
--- a/src/components/notes/NoteFormModal.tsx
+++ b/src/components/notes/NoteFormModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Student } from '@prisma/client'
+import type { Student } from '@prisma/client'
 import { SessionWithGroup } from '@/types/schedule'
 
 interface NoteFormModalProps {

--- a/src/components/schedule/ScheduleBlock.tsx
+++ b/src/components/schedule/ScheduleBlock.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import SessionModal from './SessionModal'
-import { Student } from '@prisma/client'
+import type { Student } from '@prisma/client'
 import { SessionWithGroup } from '@/types/schedule'
 
 interface Props {

--- a/src/components/schedule/ScheduleGrid.tsx
+++ b/src/components/schedule/ScheduleGrid.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition, Fragment } from 'react'
 import { addDays } from '@/utils/date'
 import { getSessionsForRange } from '@/app/schedule/actions'
 import ScheduleBlock from './ScheduleBlock'
-import { Student } from '@prisma/client'
+import type { Student } from '@prisma/client'
 import { SessionWithGroup } from '@/types/schedule'
 
 interface Props {

--- a/src/components/schedule/SessionModal.tsx
+++ b/src/components/schedule/SessionModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Student } from '@prisma/client'
+import type { Student } from '@prisma/client'
 import { saveSession } from '@/app/schedule/actions'
 import { SessionWithGroup, SessionStatus, SESSION_STATUSES } from '@/types/schedule'
 

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,4 +1,4 @@
-import { Session, Group, Student } from '@prisma/client'
+import type { Session, Group, Student } from '@prisma/client'
 
 export type SessionStatus = 'UPCOMING' | 'SEEN' | 'MISSED'
 


### PR DESCRIPTION
## Summary
- use type-only imports for Prisma types in client-side schedule components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed: yarn add --dev eslint)*
- `npm run lint` after attempting installation *(still fails: ESLint must be installed: yarn add --dev eslint)*
- `npm run build` *(fails: ESLint must be installed in order to run during builds: yarn add --dev eslint; The table `main.Session` does not exist in the current database)*

------
https://chatgpt.com/codex/tasks/task_e_6896dd1467108330a05c658461eb3b87