### PR TITLE
feat: add global quick student search

### DIFF
--- a/src/app/api/search/students/route.ts
+++ b/src/app/api/search/students/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { getUpcomingSessionsForStudents } from '@/lib/sessions'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const q = searchParams.get('q')?.trim() || ''
+  if (q.length < 2) {
+    return NextResponse.json([], {
+      status: 400,
+      headers: { 'X-Debounce': '300' },
+    })
+  }
+  try {
+    const students = await prisma.student.findMany({
+      where: {
+        OR: [
+          { firstName: { contains: q, mode: 'insensitive' } },
+          { lastName: { contains: q, mode: 'insensitive' } },
+        ],
+      },
+      include: {
+        teacher: true,
+        classroom: true,
+      },
+      orderBy: { firstName: 'asc' },
+      take: 10,
+    })
+    const sessionsMap = await getUpcomingSessionsForStudents(
+      students.map((s) => s.id),
+    )
+    const results = students.map((s) => ({
+      id: s.id,
+      firstName: s.firstName,
+      lastName: s.lastName,
+      grade: s.grade,
+      teacher: s.teacher.name,
+      classroom: s.classroom.name,
+      upcomingSessions: sessionsMap[s.id] || [],
+    }))
+    return NextResponse.json(results)
+  } catch (e) {
+    console.error(e)
+    return NextResponse.json([])
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css'
 import Link from 'next/link'
 import type { ReactNode } from 'react'
+import QuickStudentSearch from '@/components/QuickStudentSearch'
 
 export const metadata = {
   title: 'SLP Pink Studio',
@@ -11,7 +12,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className="flex min-h-screen bg-gray-50">
-        <nav className="w-64 bg-primary text-white p-4 rounded-r-md">
+        <nav className="w-64 rounded-r-md bg-primary p-4 text-white">
           <h1 className="mb-8 text-2xl font-semibold">SLP Pink Studio</h1>
           <ul className="space-y-2">
             <li>
@@ -31,7 +32,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             </li>
           </ul>
         </nav>
-        <main className="flex-1 p-8">{children}</main>
+        <div className="flex flex-1 flex-col p-8">
+          <header className="mb-4 flex justify-end">
+            <QuickStudentSearch />
+          </header>
+          <main className="flex-1">{children}</main>
+        </div>
       </body>
     </html>
   )

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -9,7 +9,11 @@ function startOfCurrentWeek() {
   return new Date(now.getFullYear(), now.getMonth(), diff)
 }
 
-export default async function SchedulePage() {
+export default async function SchedulePage({
+  searchParams,
+}: {
+  searchParams: { studentId?: string }
+}) {
   const weekStart = startOfCurrentWeek()
   const sessions = await prisma.session.findMany({
     where: { date: { gte: weekStart, lt: new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000) } },
@@ -20,6 +24,7 @@ export default async function SchedulePage() {
   const students = await prisma.student.findMany({ orderBy: { firstName: 'asc' } })
   const sessionForNote = sessions[0]
   const studentForNote = sessionForNote?.group?.students[0] || students[0]
+  const highlightStudentId = searchParams.studentId ? Number(searchParams.studentId) : undefined
   return (
     <section className="rounded-md bg-white p-2 shadow">
       <h2 className="mb-4 text-xl font-semibold">Schedule</h2>
@@ -27,6 +32,7 @@ export default async function SchedulePage() {
         initialWeekStart={weekStart}
         initialSessions={sessions as any}
         teachers={teachers}
+        highlightStudentId={highlightStudentId}
       />
       {sessionForNote && studentForNote && (
         <div className="mt-4">

--- a/src/app/students/[id]/page.tsx
+++ b/src/app/students/[id]/page.tsx
@@ -1,0 +1,21 @@
+import prisma from '@/lib/prisma'
+
+export default async function StudentPage({ params }: { params: { id: string } }) {
+  const student = await prisma.student.findUnique({
+    where: { id: Number(params.id) },
+    include: { teacher: true, classroom: true },
+  })
+  if (!student) {
+    return <div className="p-4">Student not found</div>
+  }
+  return (
+    <section className="rounded-md bg-white p-6 shadow">
+      <h2 className="text-xl font-semibold">
+        {student.firstName} {student.lastName}
+      </h2>
+      <p className="mt-2 text-gray-600">Grade: {student.grade}</p>
+      <p className="mt-1 text-gray-600">Teacher: {student.teacher.name}</p>
+      <p className="mt-1 text-gray-600">Classroom: {student.classroom.name}</p>
+    </section>
+  )
+}

--- a/src/components/QuickStudentSearch.tsx
+++ b/src/components/QuickStudentSearch.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Dialog } from '@headlessui/react'
+
+interface Result {
+  id: number
+  firstName: string
+  lastName: string
+  grade: string
+  teacher: string
+  classroom: string
+  upcomingSessions: { date: string; startTime: string }[]
+}
+
+export default function QuickStudentSearch() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<Result[]>([])
+  const [active, setActive] = useState(0)
+  const [open, setOpen] = useState(false)
+  const [overlay, setOverlay] = useState<Result | null>(null)
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!query) {
+      setResults([])
+      return
+    }
+    const handle = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/search/students?q=${encodeURIComponent(query)}`)
+        if (!res.ok) {
+          setResults([])
+          return
+        }
+        const data = await res.json()
+        setResults(data)
+        setActive(0)
+        setOpen(true)
+      } catch {
+        setResults([])
+      }
+    }, 300)
+    return () => clearTimeout(handle)
+  }, [query])
+
+  const activeId = results[active] ? `student-option-${results[active].id}` : undefined
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActive((a) => (a + 1) % results.length)
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActive((a) => (a - 1 + results.length) % results.length)
+    } else if (e.key === 'Enter') {
+      const student = results[active]
+      if (student) router.push(`/students/${student.id}`)
+    }
+  }
+
+  return (
+    <div className="relative">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onFocus={() => results.length && setOpen(true)}
+        onKeyDown={onKeyDown}
+        placeholder="Search students"
+        className="w-48 rounded-md border border-primary px-2 py-1 text-sm text-pink-900 placeholder-pink-300"
+        aria-controls="student-search-results"
+        aria-expanded={open}
+        aria-activedescendant={activeId}
+      />
+      {open && results.length > 0 && (
+        <ul
+          id="student-search-results"
+          role="listbox"
+          className="absolute z-10 mt-1 w-72 rounded-md border border-primary bg-white shadow"
+        >
+          {results.map((r, i) => (
+            <li
+              key={r.id}
+              id={`student-option-${r.id}`}
+              role="option"
+              aria-selected={i === active}
+              className={`flex cursor-pointer items-center justify-between px-2 py-1 text-sm ${
+                i === active ? 'bg-primary' : ''
+              }`}
+              onMouseEnter={() => setActive(i)}
+            >
+              <div
+                className="flex-1"
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  router.push(`/students/${r.id}`)
+                  setOpen(false)
+                }}
+              >
+                <div className="font-medium">{r.firstName} {r.lastName}</div>
+                <div className="text-xs text-gray-600">
+                  {r.grade} • {r.teacher} • {r.classroom}
+                </div>
+              </div>
+              <button
+                className="ml-2 rounded bg-primary px-1 py-0.5 text-xs text-pink-900"
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  setOverlay(r)
+                }}
+              >
+                Sessions
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Dialog open={!!overlay} onClose={() => setOverlay(null)} className="relative z-20">
+        <div className="fixed inset-0 bg-black/20" aria-hidden="true" />
+        <div className="fixed inset-0 mt-20 flex items-start justify-center p-4">
+          <Dialog.Panel className="w-full max-w-sm rounded-md bg-white p-4">
+            <Dialog.Title className="text-lg font-semibold">
+              {overlay?.firstName} {overlay?.lastName}
+            </Dialog.Title>
+            <div className="mt-2 text-sm">
+              {overlay?.upcomingSessions.length ? (
+                <ul className="mb-2 list-disc pl-4">
+                  {overlay.upcomingSessions.slice(0, 3).map((s, idx) => (
+                    <li key={idx}>
+                      {new Date(s.date).toLocaleDateString()} {' '}
+                      {new Date(s.startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p>No upcoming sessions</p>
+              )}
+            </div>
+            {overlay && (
+              <button
+                className="mt-2 rounded bg-primary px-3 py-1 text-pink-900"
+                onClick={() => {
+                  router.push(`/schedule?studentId=${overlay.id}`)
+                  setOverlay(null)
+                }}
+              >
+                View in Schedule
+              </button>
+            )}
+          </Dialog.Panel>
+        </div>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/components/schedule/ScheduleBlock.tsx
+++ b/src/components/schedule/ScheduleBlock.tsx
@@ -11,9 +11,17 @@ interface Props {
   session?: SessionWithGroup
   teachers: Teacher[]
   onChange: (session: SessionWithGroup) => void
+  highlightStudentId?: number
 }
 
-export default function ScheduleBlock({ date, time, session, teachers, onChange }: Props) {
+export default function ScheduleBlock({
+  date,
+  time,
+  session,
+  teachers,
+  onChange,
+  highlightStudentId,
+}: Props) {
   const [open, setOpen] = useState(false)
 
   const status = session?.status ?? 'UPCOMING'
@@ -25,11 +33,15 @@ export default function ScheduleBlock({ date, time, session, teachers, onChange 
       : session
       ? 'bg-[#f5bcd6]'
       : ''
+  const highlight =
+    highlightStudentId && session?.group?.students.some((s) => s.id === highlightStudentId)
 
   return (
     <>
       <div
-        className={`h-16 w-full border p-1 text-xs cursor-pointer ${color}`}
+        className={`h-16 w-full cursor-pointer border p-1 text-xs ${color} ${
+          highlight ? 'ring-2 ring-primary' : ''
+        }`}
         onClick={() => setOpen(true)}
       >
         {session && (

--- a/src/components/schedule/ScheduleGrid.tsx
+++ b/src/components/schedule/ScheduleGrid.tsx
@@ -11,6 +11,7 @@ interface Props {
   initialWeekStart: Date
   initialSessions: SessionWithGroup[]
   teachers: Teacher[]
+  highlightStudentId?: number
 }
 
 const times = Array.from({ length: 8 }, (_, i) => `${8 + i}:00`)
@@ -20,6 +21,7 @@ export default function ScheduleGrid({
   initialWeekStart,
   initialSessions,
   teachers,
+  highlightStudentId,
 }: Props) {
   const [weekStart, setWeekStart] = useState(new Date(initialWeekStart))
   const [sessions, setSessions] = useState<SessionWithGroup[]>(initialSessions)
@@ -100,6 +102,7 @@ export default function ScheduleGrid({
                   session={session}
                   teachers={teachers}
                   onChange={upsertSession}
+                  highlightStudentId={highlightStudentId}
                 />
               )
             })}

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -1,0 +1,39 @@
+import prisma from '@/lib/prisma'
+
+export interface SimpleSession {
+  date: Date
+  startTime: Date
+}
+
+/**
+ * Returns up to `take` upcoming sessions for the provided student IDs.
+ */
+export async function getUpcomingSessionsForStudents(
+  studentIds: number[],
+  take = 3,
+): Promise<Record<number, SimpleSession[]>> {
+  if (studentIds.length === 0) return {}
+  const sessions = await prisma.session.findMany({
+    where: {
+      date: { gte: new Date() },
+      group: { students: { some: { id: { in: studentIds } } } },
+    },
+    include: {
+      group: { include: { students: { select: { id: true } } } },
+    },
+    orderBy: [{ date: 'asc' }, { startTime: 'asc' }],
+  })
+
+  const map: Record<number, SimpleSession[]> = {}
+  for (const s of sessions) {
+    for (const st of s.group?.students || []) {
+      if (!studentIds.includes(st.id)) continue
+      const arr = map[st.id] || []
+      if (arr.length < take) {
+        arr.push({ date: s.date, startTime: s.startTime })
+        map[st.id] = arr
+      }
+    }
+  }
+  return map
+}


### PR DESCRIPTION
## Summary
- add <QuickStudentSearch /> with keyboard navigation and session overlay
- expose /api/search/students for debounced student lookup
- highlight student sessions on schedule when accessed with ?studentId

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm install eslint --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896e26975288330982ff625b663d3f1