### PR TITLE
Enable group session editing with apply-to-all support

### DIFF
--- a/prisma/migrations/20250809060632_add_activity_to_session/migration.sql
+++ b/prisma/migrations/20250809060632_add_activity_to_session/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN "activity" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,6 +92,7 @@ model Session {
   startTime DateTime
   endTime   DateTime
   location  String
+  activity  String?
   group     Group?   @relation(fields: [groupId], references: [id])
   groupId   Int?
   notes     Note[]

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const id = Number(params.id)
+  const data = await req.json()
+  const { date, startTime, endTime, location, activity, status, applyToAll } = data
+
+  const start = new Date(`${date}T${startTime}:00`)
+  const end = new Date(`${date}T${endTime}:00`)
+  const sessionDate = new Date(date)
+
+  const existing = await prisma.session.findUnique({
+    where: { id },
+    select: { groupId: true },
+  })
+
+  if (!existing) {
+    return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+  }
+
+  await prisma.$transaction(async (tx) => {
+    if (applyToAll && existing.groupId) {
+      await tx.session.updateMany({
+        where: { groupId: existing.groupId },
+        data: { date: sessionDate, startTime: start, endTime: end, location, activity, status },
+      })
+    } else {
+      await tx.session.update({
+        where: { id },
+        data: { date: sessionDate, startTime: start, endTime: end, location, activity, status },
+      })
+    }
+  })
+
+  const updated = await prisma.session.findUnique({
+    where: { id },
+    include: { group: { include: { students: true } } },
+  })
+
+  return NextResponse.json(updated)
+}

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const { date, startTime, endTime, location, activity, studentIds = [], groupName, status } = data
+
+  const start = new Date(`${date}T${startTime}:00`)
+  const end = new Date(`${date}T${endTime}:00`)
+  const sessionDate = new Date(date)
+
+  let groupId: number | undefined
+  if (studentIds.length > 0) {
+    const group = await prisma.group.create({
+      data: {
+        name: groupName || 'Session Group',
+        students: { connect: studentIds.map((id: number) => ({ id })) },
+      },
+    })
+    groupId = group.id
+  }
+
+  const session = await prisma.session.create({
+    data: {
+      date: sessionDate,
+      startTime: start,
+      endTime: end,
+      location,
+      activity,
+      groupId,
+      status,
+    },
+  })
+
+  const saved = await prisma.session.findUnique({
+    where: { id: session.id },
+    include: { group: { include: { students: true } } },
+  })
+
+  return NextResponse.json(saved)
+}


### PR DESCRIPTION
## Summary
- add activity field and group link to session model
- expose POST/PATCH session APIs with optional apply-to-all group updates
- enhance session modal with group member list, activity input, and apply-to-group toggle

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6896e41a44188330b185fd319eff4d38