### PR TITLE
feat: mark group sessions seen with sequential notes

### DIFF
--- a/src/app/api/groups/[id]/mark-seen/route.ts
+++ b/src/app/api/groups/[id]/mark-seen/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const groupId = Number(params.id)
+  if (isNaN(groupId)) {
+    return NextResponse.json({ error: 'Invalid group id' }, { status: 400 })
+  }
+
+  const sessions = await prisma.$transaction(async (tx) => {
+    await tx.session.updateMany({
+      where: { groupId },
+      data: { status: 'SEEN' },
+    })
+    return tx.session.findMany({
+      where: { groupId },
+      include: { group: { include: { students: true } } },
+    })
+  })
+
+  return NextResponse.json(sessions)
+}

--- a/src/components/notes/NoteFormModal.tsx
+++ b/src/components/notes/NoteFormModal.tsx
@@ -7,38 +7,91 @@ import { SessionWithGroup } from '@/types/schedule'
 interface NoteFormModalProps {
   student: Student
   session: SessionWithGroup
+  open?: boolean
+  onClose?: () => void
+  onSkip?: () => void
+  onSave?: () => void
+  progress?: { current: number; total: number }
 }
 
-export default function NoteFormModal({ student, session }: NoteFormModalProps) {
-  const [open, setOpen] = useState(false)
+export default function NoteFormModal({
+  student,
+  session,
+  open: controlledOpen,
+  onClose,
+  onSkip,
+  onSave,
+  progress,
+}: NoteFormModalProps) {
+  const [internalOpen, setInternalOpen] = useState(false)
+  const [text, setText] = useState('')
+  const isControlled = controlledOpen !== undefined
+  const open = isControlled ? controlledOpen : internalOpen
+
+  function close() {
+    if (!isControlled) setInternalOpen(false)
+    onClose?.()
+  }
+
+  async function handleSave() {
+    await fetch('/api/notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text,
+        sessionId: session.id,
+        studentId: student.id,
+      }),
+    })
+    onSave?.()
+    close()
+  }
 
   return (
     <>
-      <button
-        onClick={() => setOpen(true)}
-        className="rounded bg-pink-200 px-2 py-1 text-pink-900"
-      >
-        Add Note
-      </button>
+      {!isControlled && (
+        <button
+          onClick={() => setInternalOpen(true)}
+          className="rounded bg-pink-200 px-2 py-1 text-pink-900"
+        >
+          Add Note
+        </button>
+      )}
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30">
-          <div className="rounded-lg bg-white p-4 shadow-lg text-sm">
+          <div className="rounded-lg bg-white p-4 text-sm shadow-lg">
+            {progress && (
+              <div className="mb-1 text-xs text-pink-800">
+                Student {progress.current} of {progress.total}
+              </div>
+            )}
             <h2 className="mb-2 text-lg font-semibold text-pink-800">
               Add Note for {student.firstName} {student.lastName}
             </h2>
-            <p className="mb-2">
-              Session: {session.group?.name || 'Session'}
-            </p>
+            <p className="mb-2">Session: {session.group?.name || 'Session'}</p>
             <textarea
               className="w-full rounded border border-pink-300 bg-pink-100 p-1"
               rows={4}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
             ></textarea>
-            <div className="mt-2 flex justify-end">
+            <div className="mt-2 flex justify-end gap-2">
+              {onSkip && (
+                <button
+                  onClick={() => {
+                    onSkip()
+                    close()
+                  }}
+                  className="rounded bg-pink-200 px-3 py-1 text-pink-900"
+                >
+                  Skip
+                </button>
+              )}
               <button
-                onClick={() => setOpen(false)}
-                className="rounded bg-pink-200 px-3 py-1 text-pink-900"
+                onClick={handleSave}
+                className="rounded bg-pink-500 px-3 py-1 text-white"
               >
-                Close
+                Save
               </button>
             </div>
           </div>
@@ -47,4 +100,3 @@ export default function NoteFormModal({ student, session }: NoteFormModalProps) 
     </>
   )
 }
-


### PR DESCRIPTION
## Summary
- add API endpoint to mark all sessions in a group as seen
- extend note modal to support sequential student notes with save/skip
- allow marking an entire group seen from session modal and cycle through note forms

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint must be installed)
- `npm run build` (fails: ESLint must be installed in order to run during builds; then type error in search route)


------
https://chatgpt.com/codex/tasks/task_e_6896e6908ad08330911a88ef85defe3a