### PR TITLE
refactor: top navigation and schedule safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ npm test
 - **S** – Save note
 - **⌘K / Ctrl+K** – Quick search
 
+## QA Notes
+
+- Initialize the database with `npx prisma db push` or POST to `/api/admin/init-db`.
+- Create a session by clicking a 10:00 slot and confirm default time 10:00–10:30.
+- Attempt to save a session without times – the client blocks save and the server returns `400`.
+- Mark a session seen only when valid times are present.
+- Drag and drop a session to reschedule and verify the time persists.
+- Keyboard shortcuts: **N** for new session, **S** to save note, **⌘K / Ctrl+K** for search.
+
 ## School Closure CSV Format
 
 Upload CSV files with the following columns:

--- a/src/app/api/admin/init-db/route.ts
+++ b/src/app/api/admin/init-db/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import { execSync } from 'child_process'
+
+export async function POST() {
+  try {
+    execSync('npx prisma db push', { stdio: 'ignore' })
+    return NextResponse.json({ ok: true })
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e.message }, { status: 500 })
+  }
+}

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -8,9 +8,15 @@ export async function PATCH(
   const id = Number(params.id)
   const data = await req.json()
   const { date, startTime, endTime, location, activity, status, applyToAll } = data
+  if (!date || !startTime || !endTime) {
+    return NextResponse.json({ error: 'date, startTime and endTime are required' }, { status: 400 })
+  }
 
   const start = new Date(`${date}T${startTime}:00`)
   const end = new Date(`${date}T${endTime}:00`)
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+    return NextResponse.json({ error: 'Invalid time format' }, { status: 400 })
+  }
   const sessionDate = new Date(date)
 
   const existing = await prisma.session.findUnique({

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -4,9 +4,15 @@ import prisma from '@/lib/prisma'
 export async function POST(req: Request) {
   const data = await req.json()
   const { date, startTime, endTime, location, activity, studentIds = [], groupName, status } = data
+  if (!date || !startTime || !endTime) {
+    return NextResponse.json({ error: 'date, startTime and endTime are required' }, { status: 400 })
+  }
 
   const start = new Date(`${date}T${startTime}:00`)
   const end = new Date(`${date}T${endTime}:00`)
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+    return NextResponse.json({ error: 'Invalid time format' }, { status: 400 })
+  }
   const sessionDate = new Date(date)
 
   let groupId: number | undefined

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,5 @@
+@import '../styles/theme.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,42 +2,45 @@ import './globals.css'
 import Link from 'next/link'
 import type { ReactNode } from 'react'
 import QuickStudentSearch from '@/components/QuickStudentSearch'
+import Button from '@/components/ui/Button'
 
 export const metadata = {
   title: 'SLP Pink Studio',
-  description: 'School-based speech-language pathologist dashboard'
+  description: 'School-based speech-language pathologist dashboard',
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="flex min-h-screen bg-gray-50">
-        <nav className="w-64 rounded-r-md bg-primary p-4 text-white">
-          <h1 className="mb-8 text-2xl font-semibold">SLP Pink Studio</h1>
-          <ul className="space-y-2">
-            <li>
-              <Link href="/" className="block rounded-md px-4 py-2 hover:bg-white/20">Dashboard</Link>
-            </li>
-            <li>
-              <Link href="/students" className="block rounded-md px-4 py-2 hover:bg-white/20">Students</Link>
-            </li>
-            <li>
-              <Link href="/schedule" className="block rounded-md px-4 py-2 hover:bg-white/20">Schedule</Link>
-            </li>
-            <li>
-              <Link href="/reports" className="block rounded-md px-4 py-2 hover:bg-white/20">Reports</Link>
-            </li>
-            <li>
-              <Link href="/settings" className="block rounded-md px-4 py-2 hover:bg-white/20">Settings</Link>
-            </li>
-          </ul>
-        </nav>
-        <div className="flex flex-1 flex-col p-8">
-          <header className="mb-4 flex justify-end">
+      <body className="min-h-screen">
+        <header className="bg-pink shadow-sm">
+          <div className="mx-auto flex max-w-7xl items-center gap-4 px-4 py-2">
+            <h1 className="text-xl font-semibold">SLP Pink Studio</h1>
+            <nav className="flex gap-4 text-sm">
+              <Link href="/" className="hover:text-pink-600">
+                Dashboard
+              </Link>
+              <Link href="/students" className="hover:text-pink-600">
+                Students
+              </Link>
+              <Link href="/schedule" className="hover:text-pink-600">
+                Schedule
+              </Link>
+              <Link href="/reports" className="hover:text-pink-600">
+                Reports
+              </Link>
+              <Link href="/settings" className="hover:text-pink-600">
+                Settings
+              </Link>
+            </nav>
+            <div className="flex-1" />
             <QuickStudentSearch />
-          </header>
-          <main className="flex-1">{children}</main>
-        </div>
+            <Link href="/schedule" className="ml-4">
+              <Button>New Session</Button>
+            </Link>
+          </div>
+        </header>
+        <main className="mx-auto max-w-7xl p-4 fade-up">{children}</main>
       </body>
     </html>
   )

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,6 +1,9 @@
 import ScheduleGrid from '@/components/schedule/ScheduleGrid'
 import NoteFormModal from '@/components/notes/NoteFormModal'
 import prisma from '@/lib/prisma'
+import Card from '@/components/ui/Card'
+import EmptyState from '@/components/ui/EmptyState'
+import Button from '@/components/ui/Button'
 
 function startOfCurrentWeek() {
   const now = new Date()
@@ -15,30 +18,48 @@ export default async function SchedulePage({
   searchParams: { studentId?: string }
 }) {
   const weekStart = startOfCurrentWeek()
-  const sessions = await prisma.session.findMany({
-    where: { date: { gte: weekStart, lt: new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000) } },
-    include: { group: { include: { students: true } } },
-    orderBy: { startTime: 'asc' },
-  })
-  const teachers = await prisma.teacher.findMany({ orderBy: { name: 'asc' } })
-  const students = await prisma.student.findMany({ orderBy: { firstName: 'asc' } })
-  const sessionForNote = sessions[0]
-  const studentForNote = sessionForNote?.group?.students[0] || students[0]
-  const highlightStudentId = searchParams.studentId ? Number(searchParams.studentId) : undefined
-  return (
-    <section className="rounded-md bg-white p-2 shadow">
-      <h2 className="mb-4 text-xl font-semibold">Schedule</h2>
-      <ScheduleGrid
-        initialWeekStart={weekStart}
-        initialSessions={sessions as any}
-        teachers={teachers}
-        highlightStudentId={highlightStudentId}
-      />
-      {sessionForNote && studentForNote && (
-        <div className="mt-4">
-          <NoteFormModal student={studentForNote} session={sessionForNote as any} />
-        </div>
-      )}
-    </section>
-  )
+  try {
+    const sessions = await prisma.session.findMany({
+      where: {
+        date: {
+          gte: weekStart,
+          lt: new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000),
+        },
+      },
+      include: { group: { include: { students: true } } },
+      orderBy: { startTime: 'asc' },
+    })
+    const teachers = await prisma.teacher.findMany({ orderBy: { name: 'asc' } })
+    const students = await prisma.student.findMany({ orderBy: { firstName: 'asc' } })
+    const sessionForNote = sessions[0]
+    const studentForNote = sessionForNote?.group?.students[0] || students[0]
+    const highlightStudentId = searchParams.studentId ? Number(searchParams.studentId) : undefined
+    return (
+      <Card className="fade-up">
+        <h2 className="mb-4 text-xl font-semibold">Schedule</h2>
+        <ScheduleGrid
+          initialWeekStart={weekStart}
+          initialSessions={sessions as any}
+          teachers={teachers}
+          highlightStudentId={highlightStudentId}
+        />
+        {sessionForNote && studentForNote && (
+          <div className="mt-4">
+            <NoteFormModal student={studentForNote} session={sessionForNote as any} />
+          </div>
+        )}
+      </Card>
+    )
+  } catch (e: any) {
+    if (e.code === 'P2021') {
+      return (
+        <EmptyState title="Database not initialized" description="Initialize database to continue">
+          <form action="/api/admin/init-db" method="post">
+            <Button type="submit">Initialize Database</Button>
+          </form>
+        </EmptyState>
+      )
+    }
+    throw e
+  }
 }

--- a/src/components/QuickStudentSearch.tsx
+++ b/src/components/QuickStudentSearch.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Dialog } from '@headlessui/react'
 
@@ -21,6 +21,7 @@ export default function QuickStudentSearch() {
   const [open, setOpen] = useState(false)
   const [overlay, setOverlay] = useState<Result | null>(null)
   const router = useRouter()
+  const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (!query) {
@@ -45,6 +46,17 @@ export default function QuickStudentSearch() {
     return () => clearTimeout(handle)
   }, [query])
 
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        inputRef.current?.focus()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
   const activeId = results[active] ? `student-option-${results[active].id}` : undefined
 
   function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
@@ -63,13 +75,14 @@ export default function QuickStudentSearch() {
   return (
     <div className="relative">
       <input
+        ref={inputRef}
         type="text"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         onFocus={() => results.length && setOpen(true)}
         onKeyDown={onKeyDown}
         placeholder="Search students"
-        className="w-48 rounded-md border border-primary px-2 py-1 text-sm text-pink-900 placeholder-pink-300"
+        className="w-48 rounded-2xl border border-pink-600 px-2 py-1 text-sm text-text placeholder-pink-300 focus:outline-none focus:ring-2 focus:ring-pink-600"
         aria-controls="student-search-results"
         aria-expanded={open}
         aria-activedescendant={activeId}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React from 'react'
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -7,11 +8,11 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 export default function Button({ variant = 'primary', className = '', ...props }: ButtonProps) {
   const variantClasses =
     variant === 'primary'
-      ? 'bg-[#f5bcd6] text-gray-800 hover:bg-[#f1a7c8]'
-      : 'bg-gray-200 text-gray-800 hover:bg-gray-300'
+      ? 'bg-pink text-text hover:bg-pink-600'
+      : 'bg-gray-200 text-text hover:bg-gray-300'
   return (
     <button
-      className={`rounded-2xl px-4 py-2 text-sm font-medium shadow-sm focus:outline-none transition-colors ${variantClasses} ${className}`}
+      className={`rounded-2xl px-4 py-2 text-sm font-medium shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-pink-600 ${variantClasses} ${className}`}
       {...props}
     />
   )

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Card({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+  return <div className={`rounded-2xl bg-white p-4 shadow-sm ${className}`}>{children}</div>
+}

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,30 @@
+"use client"
+import React from 'react'
+import Button from './Button'
+
+interface Props {
+  title: string
+  description: string
+  actionLabel?: string
+  onAction?: () => void
+  children?: React.ReactNode
+}
+
+export default function EmptyState({ title, description, actionLabel, onAction, children }: Props) {
+  return (
+    <div className="flex flex-col items-center justify-center p-8 text-center text-text">
+      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-pink-600">
+        <circle cx="12" cy="12" r="10" />
+        <line x1="8" y1="12" x2="16" y2="12" />
+      </svg>
+      <h3 className="mt-2 text-lg font-semibold">{title}</h3>
+      <p className="mt-1 text-sm">{description}</p>
+      {actionLabel && onAction && (
+        <Button className="mt-4" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      )}
+      {children && <div className="mt-4">{children}</div>}
+    </div>
+  )
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,15 @@
+'use client'
+import React, { forwardRef } from 'react'
+
+export default forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(function Input(
+  { className = '', ...props },
+  ref,
+) {
+  return (
+    <input
+      ref={ref}
+      className={`w-full rounded-2xl border border-pink-600 px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-pink-600 ${className}`}
+      {...props}
+    />
+  )
+})

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,25 @@
+export function parseTime(time: string): Date {
+  const [hour, minute] = time.split(':').map(Number)
+  const d = new Date()
+  d.setHours(hour, minute, 0, 0)
+  return d
+}
+
+export function formatTime(date: Date): string {
+  return date.toISOString().substring(11, 16)
+}
+
+export function getDefaultSlotTimes({
+  hour,
+  minute,
+  slotMinutes,
+}: {
+  hour: number
+  minute: number
+  slotMinutes: number
+}): { startTime: string; endTime: string } {
+  const start = new Date()
+  start.setHours(hour, minute, 0, 0)
+  const end = new Date(start.getTime() + slotMinutes * 60000)
+  return { startTime: formatTime(start), endTime: formatTime(end) }
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,21 @@
+:root {
+  --pink: #f5bcd6;
+  --pink-600: #e09cbf;
+  --text: #374151;
+  --bg-start: #fff7fb;
+  --bg-end: #ffeef6;
+}
+
+body {
+  color: var(--text);
+  background: radial-gradient(circle at top center, var(--bg-start), var(--bg-end));
+}
+
+@keyframes fade-up {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.fade-up {
+  animation: fade-up 0.3s ease-out;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,10 +5,17 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: "#f5bcd6"
+        pink: 'var(--pink)',
+        'pink-600': 'var(--pink-600)',
+        text: 'var(--text)',
+        primary: 'var(--pink)'
       },
       borderRadius: {
-        DEFAULT: "0.5rem"
+        '2xl': '1rem'
+      },
+      boxShadow: {
+        sm: '0 1px 2px rgba(0,0,0,0.05)',
+        md: '0 4px 6px rgba(0,0,0,0.1)'
       }
     }
   },


### PR DESCRIPTION
## Summary
- introduce theme variables and top bar layout with quick search and new session button
- add time utilities and validation for sessions with database init helper
- provide QA notes and subtle fade-up animation helper

## Testing
- `npm test` *(fails: The table `main.SessionTemplate` does not exist in the current database)*
- `npm run build` *(fails: ESLint must be installed; Prisma tables missing)*

------
https://chatgpt.com/codex/tasks/task_e_6896f02d146c8330b9e0cb43f820aa01